### PR TITLE
Use is_alive for Python 3.9 compatibility

### DIFF
--- a/src/lib/browser/threadpool.py
+++ b/src/lib/browser/threadpool.py
@@ -45,7 +45,7 @@ class ThreadPool(object):
         for _ in range(num_threads):
 
             worker = Worker(self.__queue, num_threads, timeout)
-            if False is worker.isAlive():
+            if False is worker.is_alive():
                 worker.setDaemon(True)
                 worker.start()
                 self.__workers.append(worker)


### PR DESCRIPTION
isAlive has been removed in Python 3.9 

![image](https://user-images.githubusercontent.com/26071783/103162928-a2760780-47bc-11eb-9662-83f7eb80df30.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanislav-web/opendoor/46)
<!-- Reviewable:end -->
