### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/src/core/helper/helper.py
+++ b/src/core/helper/helper.py
@@ -24,6 +24,11 @@ import webbrowser
 from urllib.parse import urlparse
 from distutils.version import LooseVersion
 
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 
 class Helper(object):
 
@@ -124,7 +129,7 @@ class Helper(object):
         :return: bool
         """
 
-        return isinstance(func, collections.Callable)
+        return isinstance(func, Callable)
 
     @staticmethod
     def decode_hostname(hostname):


### PR DESCRIPTION
Added try/except since Python 3.3 seems to be supported as per setup.py . If not then `collections.abc` can be used directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanislav-web/opendoor/49)
<!-- Reviewable:end -->
