### PR TITLE
Add "packaging" to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 urllib3
 json2html
 tabulate
+packaging


### PR DESCRIPTION
I ran these instructions from the README:

```
 git clone https://github.com/stanislav-web/OpenDoor.git
 cd OpenDoor/
 pip3 install -r requirements.txt
 chmod +x opendoor.py
```

Then when I ran `python3 opendoor.py`, I received the following error message

```
Traceback (most recent call last):
  File "/Users/<user>/OpenDoor/opendoor.py", line 31, in <module>
    from src import Controller, SrcError
  File "/Users/<user>/OpenDoor/src/__init__.py", line 21, in <module>
    from .controller import Controller
  File "/Users/<user>/OpenDoor/src/controller.py", line 19, in <module>
    from src.core.decorators import execution_time
  File "/Users/<user>/OpenDoor/src/core/__init__.py", line 29, in <module>
    from .helper import Helper as helper
  File "/Users/<user>/OpenDoor/src/core/helper/__init__.py", line 19, in <module>
    from .helper import Helper
  File "/Users/<user>/OpenDoor/src/core/helper/helper.py", line 25, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

Running `pip3 install packaging` fixed this issue, now `python3 opendoor.py` returns the help docs as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanislav-web/opendoor/55)
<!-- Reviewable:end -->
