### PR TITLE
Fixed HTTPHeaderDict issue when trying to use the last urllib3 version (Python 3.11/Kali)

### DIFF
--- a/src/core/http/providers/header.py
+++ b/src/core/http/providers/header.py
@@ -16,7 +16,7 @@
     Development Team: Brain Storm Team
 """
 
-from urllib3 import HTTPHeaderDict
+from urllib3._collections import HTTPHeaderDict
 
 from .accept import AcceptHeaderProvider
 from .cache import CacheControlProvider


### PR DESCRIPTION
Fixed the error when importing HTTPHeaderDict from Urllib3

ImportError: cannot import name 'HTTPHeaderDict' from 'urllib3' (/home/kali/.local/lib/python3.11/site-packages/urllib3/__init__.py)

Some references here:
https://stackoverflow.com/questions/70141344/attributeerror-module-urllib3-has-no-attribute-httpheaderdict

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stanislav-web/OpenDoor/67)
<!-- Reviewable:end -->
